### PR TITLE
feat: option to reset all mocks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,22 +7,25 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-- env:
-  - CGO_ENABLED=0
+  - env:
+      - CGO_ENABLED=0
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - "^docs:"
+      - "^test:"
+dockers:
+  - image_templates:
+      - psmarcin/psmockserver

--- a/pkg/mock/file.go
+++ b/pkg/mock/file.go
@@ -11,12 +11,14 @@ import (
 func LoadFromFile(path string) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
-		golog.Errorf("Can't read file %+v", err)
+		golog.Infof("Can't read file %+v", err)
+		return
 	}
 
 	payloads, err := parseFileMocks(content)
 	if err != nil {
 		golog.Errorf("Can't parse file content %s with content %s", path, content)
+		return
 	}
 
 	for _, p := range payloads {

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -62,6 +62,10 @@ func Serialize() ([]byte, error) {
 	return json.Marshal(Mocks)
 }
 
+func Reset() {
+	Mocks = make(map[string]Mock)
+}
+
 func init() {
 	LoadFromFile(config.Cfg.MocksFilePath)
 }

--- a/pkg/mock/mock_test.go
+++ b/pkg/mock/mock_test.go
@@ -111,3 +111,23 @@ func TestAdd(t *testing.T) {
 		})
 	}
 }
+
+func TestReset(t *testing.T) {
+
+	// mock
+	Add("GET|/", Mock{
+		Body: "123",
+	})
+
+	if len(Mocks) == 0 {
+		t.Fatalf("Didn't set any mock before Reset()")
+	}
+
+	// act
+	Reset()
+
+	// expect
+	if len(Mocks) != 0 {
+		t.Fatalf("Reset() should clean all mocks but got %d mocks", len(Mocks))
+	}
+}

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -1,11 +1,11 @@
 package server
 
 import (
-	"psmockserver/pkg/utils"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"psmockserver/pkg/mock"
+	"psmockserver/pkg/utils"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -22,6 +22,7 @@ func CreateRouter() *chi.Mux {
 	// routes
 	router.Post(`/mockserver`, addMockHandler)
 	router.Get(`/mockserver`, listMockHandler)
+	router.Put(`/mockserver/reset`, resetHandler)
 	router.HandleFunc(`/*`, rootHandler)
 	router.NotFound(http.NotFound)
 
@@ -76,4 +77,9 @@ func addMockHandler(w http.ResponseWriter, r *http.Request) {
 			Unlimited: p.Times.Unlimited,
 		},
 	})
+}
+
+func resetHandler(w http.ResponseWriter, r *http.Request) {
+	mock.Reset()
+	w.WriteHeader(http.StatusAccepted)
 }


### PR DESCRIPTION
### Context
Option to reset all mocked routes. As it stays here: https://mock-server.com/mock_server/clearing_and_resetting.html

### Changes
1. Add new endpoint to reset all mocks
1. `mock.Reset()` function
1. Fast quit for load mocks from file