### PR TITLE
feat: request as mock id

### DIFF
--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -23,14 +23,17 @@ type Remaining struct {
 	Unlimited bool
 }
 
-var Mocks = make(map[string]Mock)
+// Mocks holds all mocks
+var Mocks = make(map[*http.Request]Mock)
 
-func Add(id string, mock Mock) error {
+// Add should add new mock to collection
+func Add(id *http.Request, mock Mock) error {
 	Mocks[id] = mock
 	return nil
 }
 
-func Find(id string) (Mock, error) {
+// Find looks for mock by id in mock collection
+func Find(id *http.Request) (Mock, error) {
 	mock, ok := Mocks[id]
 	if ok != true {
 		return mock, errors.New("Not found")
@@ -51,21 +54,25 @@ func Find(id string) (Mock, error) {
 	return Mock{}, errors.New("Not found")
 }
 
+// List logs all mocked endpoints
 func List() {
 	golog.Infof("Mocks list: ")
 	for x := range Mocks {
-		golog.Infof("\t - %s", x)
+		golog.Infof("\t - %s %s", x.Method, x.RequestURI)
 	}
 }
 
+// Serialize marshals json
 func Serialize() ([]byte, error) {
 	return json.Marshal(Mocks)
 }
 
+// Reset cleanup mock collection
 func Reset() {
-	Mocks = make(map[string]Mock)
+	Mocks = make(map[*http.Request]Mock)
 }
 
+// init loads mocks from file
 func init() {
 	LoadFromFile(config.Cfg.MocksFilePath)
 }

--- a/pkg/mock/mock_test.go
+++ b/pkg/mock/mock_test.go
@@ -8,8 +8,9 @@ import (
 
 func TestFind(t *testing.T) {
 	type args struct {
-		id string
+		id *http.Request
 	}
+	id, _ := http.NewRequest(http.MethodGet, "/not-foud", nil)
 	tests := []struct {
 		name    string
 		args    args
@@ -19,7 +20,7 @@ func TestFind(t *testing.T) {
 		{
 			name: "should not find mock",
 			args: args{
-				id: "GET|/not-foud",
+				id,
 			},
 			want:    Mock{},
 			wantErr: true,
@@ -40,7 +41,7 @@ func TestFind(t *testing.T) {
 }
 
 func TestFindTimes0(t *testing.T) {
-	id := "GET|/test-mock-times-0"
+	id, _ := http.NewRequest(http.MethodGet, "/test-mock-times-0", nil)
 	m := Mock{
 		Body: "test-mock-times-0",
 		RemainingTimes: Remaining{
@@ -58,7 +59,7 @@ func TestFindTimes0(t *testing.T) {
 }
 
 func TestFindShouldDecreaseTimes(t *testing.T) {
-	id := "GET|/test-mock-times-10"
+	id, _ := http.NewRequest(http.MethodGet, "/test-mock-times-10", nil)
 	m := Mock{
 		Body: "test-mock-times-10",
 		RemainingTimes: Remaining{
@@ -81,9 +82,10 @@ func TestFindShouldDecreaseTimes(t *testing.T) {
 
 func TestAdd(t *testing.T) {
 	type args struct {
-		id   string
+		id   *http.Request
 		mock Mock
 	}
+	id, _ := http.NewRequest(http.MethodGet, "/", nil)
 	tests := []struct {
 		name    string
 		args    args
@@ -92,7 +94,7 @@ func TestAdd(t *testing.T) {
 		{
 			name: "should add mock to root handler",
 			args: args{
-				id: "GET|/",
+				id: id,
 				mock: Mock{
 					Body:        "test",
 					Headers:     http.Header{},
@@ -113,9 +115,9 @@ func TestAdd(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
-
+	id, _ := http.NewRequest(http.MethodGet, "/", nil)
 	// mock
-	Add("GET|/", Mock{
+	Add(id, Mock{
 		Body: "123",
 	})
 

--- a/pkg/mock/payload.go
+++ b/pkg/mock/payload.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/kataras/golog"
 )
@@ -61,6 +60,8 @@ func Parse(body []byte) (Payload, error) {
 	return payload, nil
 }
 
-func GetMockHash(method, path string) string {
-	return fmt.Sprintf("%s|%s", strings.ToUpper(method), path)
+// GetMockHash returns id for mock
+func GetMockHash(method, path string) *http.Request {
+	id, _ := http.NewRequest(method, path, nil)
+	return id
 }

--- a/pkg/mock/payload_test.go
+++ b/pkg/mock/payload_test.go
@@ -248,10 +248,16 @@ func TestGetMockHash(t *testing.T) {
 		method string
 		path   string
 	}
+
+	id1, _ := http.NewRequest("get", "/", nil)
+	id2, _ := http.NewRequest(http.MethodGet, "/", nil)
+	id3, _ := http.NewRequest("poST", "/", nil)
+	id4, _ := http.NewRequest(http.MethodGet, "/nested/values", nil)
+
 	tests := []struct {
 		name string
 		args args
-		want string
+		want *http.Request
 	}{
 		{
 			name: "METHOD=get, PATH=/",
@@ -259,7 +265,7 @@ func TestGetMockHash(t *testing.T) {
 				method: "get",
 				path:   "/",
 			},
-			want: "GET|/",
+			want: id1,
 		},
 		{
 			name: "METHOD=GET, PATH=/",
@@ -267,7 +273,7 @@ func TestGetMockHash(t *testing.T) {
 				method: "GET",
 				path:   "/",
 			},
-			want: "GET|/",
+			want: id2,
 		},
 		{
 			name: "METHOD=poST, PATH=/",
@@ -275,7 +281,7 @@ func TestGetMockHash(t *testing.T) {
 				method: "poST",
 				path:   "/",
 			},
-			want: "POST|/",
+			want: id3,
 		},
 		{
 			name: "METHOD=GET, PATH=/nested/values",
@@ -283,12 +289,12 @@ func TestGetMockHash(t *testing.T) {
 				method: "GET",
 				path:   "/nested/values",
 			},
-			want: "GET|/nested/values",
+			want: id4,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetMockHash(tt.args.method, tt.args.path); got != tt.want {
+			if got := GetMockHash(tt.args.method, tt.args.path); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetMockHash() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
### Context
Previously we kept mock id as `METHOD/PATH`. Since we want to cover all kind of scenarios like query string #7 or headers we need to have richer method id. `http.Request` seams to be good as something we can begin with. 

### Meta
1. Part of #7 

### Changes
1. Change `Mocks` collection key type from `string` to `*http.Request`
1. Update tests
1. Some comments for documentation