### PR TITLE
feat: use requestid as key for mocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ release: mock-test
 
 # Mock tests
 mock-test:
-	./test/setup.sh
+	./test/setup.sh || ./test/cleanup.sh

--- a/pkg/mock/file.go
+++ b/pkg/mock/file.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kataras/golog"
 )
 
+// LoadFromFile loads default mocks from file from given path
 func LoadFromFile(path string) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -20,9 +21,12 @@ func LoadFromFile(path string) {
 		golog.Errorf("Can't parse file content %s with content %s", path, content)
 		return
 	}
-
 	for _, p := range payloads {
-		Add(GetMockHash(p.HttpRequest.Method, p.HttpRequest.Path), Mock{
+		Add(GetMockHash(RequestId{
+			Method:       p.HttpRequest.Method,
+			Path:         p.HttpRequest.Path,
+			QueryStrings: p.HttpRequest.QueryStrings,
+		}), Mock{
 			Headers:     utils.AddHeaders(p.HttpResponse.Headers),
 			StatusCode:  p.HttpResponse.StatusCode,
 			Body:        p.HttpResponse.Body,
@@ -41,9 +45,5 @@ func parseFileMocks(source []byte) ([]Payload, error) {
 	var mocks []Payload
 
 	err := json.Unmarshal(source, &mocks)
-	if err != nil {
-		return mocks, err
-	}
-
-	return mocks, nil
+	return mocks, err
 }

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -41,6 +41,7 @@ func Add(id *http.Request, mock Mock) error {
 
 // Find looks for mock by id in mock collection
 func Find(id *http.Request) (Mock, error) {
+	var foundKey *http.Request
 	found := false
 	mock := Mock{}
 	for key, value := range Mocks {
@@ -48,7 +49,7 @@ func Find(id *http.Request) (Mock, error) {
 			golog.Infof("Found %s %s", key.RequestURI, key.Method)
 			found = true
 			mock = value
-			break
+			foundKey = key
 		}
 	}
 	if found != true {
@@ -61,11 +62,11 @@ func Find(id *http.Request) (Mock, error) {
 
 	if mock.RemainingTimes.Times > 0 {
 		mock.RemainingTimes.Times = mock.RemainingTimes.Times - 1
-		Mocks[id] = mock
+		Mocks[foundKey] = mock
 		return mock, nil
 	}
 
-	delete(Mocks, id)
+	delete(Mocks, foundKey)
 
 	return Mock{}, errors.New("Not found")
 }
@@ -74,7 +75,7 @@ func Find(id *http.Request) (Mock, error) {
 func List() {
 	golog.Infof("Mocks list: ")
 	for x := range Mocks {
-		golog.Infof("\t - %s %+v", x.URL.String(), x)
+		golog.Infof("\t - %s %s %s", x.Method, x.URL.String(), x.URL.Query().Encode())
 	}
 }
 

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -4,23 +4,30 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httputil"
 	"psmockserver/pkg/config"
+	"reflect"
 
 	"github.com/kataras/golog"
 )
 
 type Mock struct {
-	Body           string
-	Headers        http.Header
-	Method         string
-	StatusCode     int
-	ContentType    string
-	RemainingTimes Remaining
+	Body           string      `json:"body"`
+	Headers        http.Header `json:"headers"`
+	Method         string      `json:"method"`
+	StatusCode     int         `json:"statusCode"`
+	ContentType    string      `json:"contentType"`
+	RemainingTimes Remaining   `json:"remainingTimes"`
+}
+
+type MockWithRequest struct {
+	Mock    `json:"mock"`
+	Request string `json:"request"`
 }
 
 type Remaining struct {
-	Times     int
-	Unlimited bool
+	Times     int  `json:"times"`
+	Unlimited bool `json:"unlimited"`
 }
 
 // Mocks holds all mocks
@@ -34,8 +41,17 @@ func Add(id *http.Request, mock Mock) error {
 
 // Find looks for mock by id in mock collection
 func Find(id *http.Request) (Mock, error) {
-	mock, ok := Mocks[id]
-	if ok != true {
+	found := false
+	mock := Mock{}
+	for key, value := range Mocks {
+		if reflect.DeepEqual(&id, &key) {
+			golog.Infof("Found %s %s", key.RequestURI, key.Method)
+			found = true
+			mock = value
+			break
+		}
+	}
+	if found != true {
 		return mock, errors.New("Not found")
 	}
 
@@ -58,13 +74,22 @@ func Find(id *http.Request) (Mock, error) {
 func List() {
 	golog.Infof("Mocks list: ")
 	for x := range Mocks {
-		golog.Infof("\t - %s %s", x.Method, x.RequestURI)
+		golog.Infof("\t - %s %+v", x.URL.String(), x)
 	}
 }
 
 // Serialize marshals json
 func Serialize() ([]byte, error) {
-	return json.Marshal(Mocks)
+	var collection = make([]MockWithRequest, len(Mocks))
+	for request, mock := range Mocks {
+		url, _ := httputil.DumpRequest(request, true)
+		collection = append(collection, MockWithRequest{
+			Mock:    mock,
+			Request: string(url),
+		})
+	}
+
+	return json.Marshal(collection)
 }
 
 // Reset cleanup mock collection

--- a/pkg/mock/mock_test.go
+++ b/pkg/mock/mock_test.go
@@ -58,6 +58,24 @@ func TestFindTimes0(t *testing.T) {
 	t.Error("Find() found but expected not to found")
 }
 
+func TestFindQueryString(t *testing.T) {
+	id, _ := http.NewRequest(http.MethodGet, "/test-mock-times-0?queryString=test", nil)
+	m := Mock{
+		Body: "test-mock-times-0",
+		RemainingTimes: Remaining{
+			Times:     1,
+			Unlimited: false,
+		},
+	}
+	Add(id, m)
+	_, err := Find(id)
+	if err == nil {
+		return
+	}
+
+	t.Error("Find() found but expected not to found")
+}
+
 func TestFindShouldDecreaseTimes(t *testing.T) {
 	id, _ := http.NewRequest(http.MethodGet, "/test-mock-times-10", nil)
 	m := Mock{

--- a/pkg/mock/payload_test.go
+++ b/pkg/mock/payload_test.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -245,8 +246,9 @@ func TestParse(t *testing.T) {
 
 func TestGetMockHash(t *testing.T) {
 	type args struct {
-		method string
-		path   string
+		method       string
+		path         string
+		queryStrings url.Values
 	}
 
 	id1, _ := http.NewRequest("get", "/", nil)
@@ -262,39 +264,47 @@ func TestGetMockHash(t *testing.T) {
 		{
 			name: "METHOD=get, PATH=/",
 			args: args{
-				method: "get",
-				path:   "/",
+				method:       "get",
+				path:         "/",
+				queryStrings: url.Values{},
 			},
 			want: id1,
 		},
 		{
 			name: "METHOD=GET, PATH=/",
 			args: args{
-				method: "GET",
-				path:   "/",
+				method:       "GET",
+				path:         "/",
+				queryStrings: url.Values{},
 			},
 			want: id2,
 		},
 		{
 			name: "METHOD=poST, PATH=/",
 			args: args{
-				method: "poST",
-				path:   "/",
+				method:       "poST",
+				path:         "/",
+				queryStrings: url.Values{},
 			},
 			want: id3,
 		},
 		{
 			name: "METHOD=GET, PATH=/nested/values",
 			args: args{
-				method: "GET",
-				path:   "/nested/values",
+				method:       "GET",
+				path:         "/nested/values",
+				queryStrings: url.Values{},
 			},
 			want: id4,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetMockHash(tt.args.method, tt.args.path); !reflect.DeepEqual(got, tt.want) {
+			if got := GetMockHash(RequestId{
+				Method:       tt.args.method,
+				Path:         tt.args.path,
+				QueryStrings: url.Values{},
+			}); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetMockHash() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -31,13 +31,15 @@ func CreateRouter() *chi.Mux {
 
 func rootHandler(w http.ResponseWriter, r *http.Request) {
 	queryStrings := r.URL.Query()
-	m, err := mock.Find(mock.GetMockHash(mock.RequestId{
+	reqID := mock.GetMockHash(mock.RequestId{
 		Method:       r.Method,
-		Path:         r.RequestURI,
+		Path:         r.URL.Path,
 		QueryStrings: queryStrings,
-	}))
+	})
+	m, err := mock.Find(reqID)
 	if err != nil {
 		golog.Warnf("Didn't find mock for: %s %s", r.Method, r.RequestURI)
+		mock.List()
 		http.NotFound(w, r)
 		return
 	}

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -30,14 +30,17 @@ func CreateRouter() *chi.Mux {
 }
 
 func rootHandler(w http.ResponseWriter, r *http.Request) {
-	m, err := mock.Find(mock.GetMockHash(r.Method, r.RequestURI))
+	queryStrings := r.URL.Query()
+	m, err := mock.Find(mock.GetMockHash(mock.RequestId{
+		Method:       r.Method,
+		Path:         r.RequestURI,
+		QueryStrings: queryStrings,
+	}))
 	if err != nil {
 		golog.Warnf("Didn't find mock for: %s %s", r.Method, r.RequestURI)
-		mock.List()
 		http.NotFound(w, r)
 		return
 	}
-	golog.Infof("Found mock for %s", r.RequestURI)
 	// set headers
 	for k, v := range m.Headers {
 		w.Header().Set(k, v[0])
@@ -66,7 +69,11 @@ func addMockHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "cant parse", http.StatusBadRequest)
 		return
 	}
-	mock.Add(mock.GetMockHash(p.HttpRequest.Method, p.HttpRequest.Path), mock.Mock{
+	mock.Add(mock.GetMockHash(mock.RequestId{
+		Method:       p.HttpRequest.Method,
+		Path:         p.HttpRequest.Path,
+		QueryStrings: p.HttpRequest.QueryStrings,
+	}), mock.Mock{
 		Headers:     utils.AddHeaders(p.HttpResponse.Headers),
 		StatusCode:  p.HttpResponse.StatusCode,
 		Body:        p.HttpResponse.Body,

--- a/test/cleanup.sh
+++ b/test/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -o nounset
+set -e
+
+docker kill $(docker ps --filter ancestor=psmarcin/psmockserver:latest -q)


### PR DESCRIPTION
### Context
Since we need more are more ways to customize key for every mock I think it's best to keep custom struct with all required request details. 

### Changes
1. Use `http.Request` as key for every mock
1. Unfortunately use `reflect.DeepEqual` to compare all mocks. 
1. Cleanup after mocked tests
1. Fix finding mocks