### PR TITLE
feat: readiness and liveness endpoints

### DIFF
--- a/helm/v2/templates/deployment.yaml
+++ b/helm/v2/templates/deployment.yaml
@@ -35,11 +35,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health/l
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /health/r
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/pkg/server/healthcheck.go
+++ b/pkg/server/healthcheck.go
@@ -1,0 +1,17 @@
+package server
+
+import "net/http"
+
+// readinesHandler return proper success http status code
+func readinesHandler(w http.ResponseWriter, r *http.Request) {
+	writeStatusOK(w)
+}
+
+// livenessHandler return proper success http status code
+func livenessHandler(w http.ResponseWriter, r *http.Request) {
+	writeStatusOK(w)
+}
+
+func writeStatusOK(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/server/router.go
+++ b/pkg/server/router.go
@@ -19,6 +19,10 @@ func CreateRouter() *chi.Mux {
 	router.Use(LogMiddleware)
 	router.Use(middleware.Recoverer)
 
+	// healthcheck
+	router.Get("/health/r", readinesHandler)
+	router.Get("/health/l", livenessHandler)
+
 	// routes
 	router.Post(`/mockserver`, addMockHandler)
 	router.Get(`/mockserver`, listMockHandler)

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestReadinesEndpoint(t *testing.T) {
+	BeforeEach()
+
+	url := baseURL + "health/r"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		t.Fatalf("Expect http status to be %d but got %d", http.StatusOK, res.StatusCode)
+	}
+
+	AfterEach()
+}
+
+func TestLivenessEndpoint(t *testing.T) {
+	BeforeEach()
+
+	url := baseURL + "health/l"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		t.Fatalf("Expect http status to be %d but got %d", http.StatusOK, res.StatusCode)
+	}
+
+	AfterEach()
+}


### PR DESCRIPTION
### Context
For any valid deployment to kubernetess we need to have readiness and liveness endpoints. 
This PR adds endpoints `GET /health/r` and `GET /health/l`.

### Extras
* Closes #15 

### Changes
* [x] Add endpoint `GET /health/r` which returns only http status code `200`
* [x] Add endpoint `GET /health/l` which returns only http status code `200`
* [x] Tests
* [x] Updated helm chart to point to these endpoints