### PR TITLE
fix: sync mocks map

### DIFF
--- a/pkg/mock/file.go
+++ b/pkg/mock/file.go
@@ -12,7 +12,7 @@ import (
 func LoadFromFile(path string) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
-		golog.Infof("Can't read file %+v", err)
+		golog.Debugf("Can't read file %+v", err)
 		return
 	}
 
@@ -22,11 +22,11 @@ func LoadFromFile(path string) {
 		return
 	}
 	for _, p := range payloads {
-		Add(GetMockHash(RequestId{
+		M.Add(GetMockHash(RequestId{
 			Method:       p.HttpRequest.Method,
 			Path:         p.HttpRequest.Path,
 			QueryStrings: p.HttpRequest.QueryStrings,
-		}), Mock{
+		}), MockResponse{
 			Headers:     utils.AddHeaders(p.HttpResponse.Headers),
 			StatusCode:  p.HttpResponse.StatusCode,
 			Body:        p.HttpResponse.Body,

--- a/pkg/mock/payload.go
+++ b/pkg/mock/payload.go
@@ -7,6 +7,12 @@ import (
 	"net/url"
 )
 
+const (
+	DefaultContentType = "application/json"
+	DefaultBody        = "{\"defaultBody\": true}"
+	DefaultPath        = "/"
+)
+
 type RequestId struct {
 	Method       string
 	Path         string
@@ -36,21 +42,17 @@ type Times struct {
 	Unlimited      bool `json:"unlimited"`
 }
 
-const MockDefaultBody = `{
-					"defaultBody": true
-				}`
-
 func Parse(body []byte) (Payload, error) {
 	payload := Payload{
 		HttpRequest: HttpRequest{
 			Method:      http.MethodGet,
-			Path:        "/",
-			ContentType: "application/json",
+			Path:        DefaultPath,
+			ContentType: DefaultContentType,
 		},
 		HttpResponse: HttpResponse{
 			StatusCode: http.StatusOK,
 			Headers:    map[string]interface{}{},
-			Body:       MockDefaultBody,
+			Body:       DefaultBody,
 		},
 		Times: Times{
 			RemainingTimes: 1,

--- a/pkg/mock/payload_test.go
+++ b/pkg/mock/payload_test.go
@@ -31,7 +31,7 @@ func TestParse(t *testing.T) {
 				HttpResponse: HttpResponse{
 					StatusCode: http.StatusOK,
 					Headers:    map[string]interface{}{},
-					Body:       MockDefaultBody,
+					Body:       DefaultBody,
 				},
 				Times: Times{
 					RemainingTimes: 1,
@@ -58,7 +58,7 @@ func TestParse(t *testing.T) {
 				HttpResponse: HttpResponse{
 					StatusCode: http.StatusOK,
 					Headers:    map[string]interface{}{},
-					Body:       MockDefaultBody,
+					Body:       DefaultBody,
 				},
 				Times: Times{
 					RemainingTimes: 1,
@@ -85,7 +85,7 @@ func TestParse(t *testing.T) {
 				HttpResponse: HttpResponse{
 					StatusCode: http.StatusOK,
 					Headers:    map[string]interface{}{},
-					Body:       MockDefaultBody,
+					Body:       DefaultBody,
 				},
 				Times: Times{
 					RemainingTimes: 1,
@@ -112,7 +112,7 @@ func TestParse(t *testing.T) {
 				HttpResponse: HttpResponse{
 					StatusCode: http.StatusOK,
 					Headers:    map[string]interface{}{},
-					Body:       MockDefaultBody,
+					Body:       DefaultBody,
 				},
 				Times: Times{
 					RemainingTimes: 1,
@@ -139,7 +139,7 @@ func TestParse(t *testing.T) {
 				HttpResponse: HttpResponse{
 					StatusCode: 301,
 					Headers:    map[string]interface{}{},
-					Body:       MockDefaultBody,
+					Body:       DefaultBody,
 				},
 				Times: Times{
 					RemainingTimes: 1,
@@ -220,7 +220,7 @@ func TestParse(t *testing.T) {
 				HttpResponse: HttpResponse{
 					StatusCode: http.StatusOK,
 					Headers:    map[string]interface{}{},
-					Body:       MockDefaultBody,
+					Body:       DefaultBody,
 				},
 				Times: Times{
 					RemainingTimes: 99,

--- a/pkg/server/router_test.go
+++ b/pkg/server/router_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"psmockserver/pkg/mock"
+)
+
+func Test_rootHandler(t *testing.T) {
+	t.Run("should return default content-type", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		path := "/create"
+		id := mock.GetMockHash(mock.RequestId{
+			Method:       http.MethodGet,
+			Path:         path,
+			QueryStrings: url.Values{},
+		})
+		mock.M.Add(id, mock.MockResponse{
+			Body: "body",
+			RemainingTimes: mock.Remaining{
+				Unlimited: true,
+			},
+			ContentType: "application/json",
+		})
+
+		request, _ := http.NewRequest(http.MethodGet, path, nil)
+		CreateRouter().ServeHTTP(response, request)
+		deb, _ := mock.M.Serialize()
+		fmt.Printf("deb %s\n", deb)
+		fmt.Printf("contenttype %s", response.Header().Get("content-type"))
+		if response.Header().Get("content-type") != "application/json" {
+			t.Fatalf("expected to return %s but got %s", "application/json", response.Header().Get("content-type"))
+		}
+	})
+}


### PR DESCRIPTION
### Context
While making multiple read/write operations to global mocks instance go throws error. Have to use sync to keep state in one form. 

### Changes
1. Use `sync` package to keep reads and writes in order
1. Move constant strings to consts

### Extras
1. Closes #19 